### PR TITLE
Style: centers every image that is the only child in a paragraph

### DIFF
--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -61,3 +61,9 @@ strong {
         max-width: 1626px !important;
     }
 }
+
+/* Centers every image that is the only child in a paragraph. */
+.page p img:only-child {
+  display: block;
+  margin: 0 auto 20px;
+}


### PR DESCRIPTION
Closes #52

Added CSS code to center every image that is the only child in a paragraph.
```css
.page p img:only-child {
  display: block;
  margin: 0 auto 20px;
}
```
Something like this will be centered:
```html
<p><img src="...></img></p>
```
And this won't be affected:
```html
<p><b>Result:</b><img src="...></img></p>
```

But there is a problem, since text are not elements and `:only-child` only cares about elements, this will be matched too:
```html
<p>Some text here <img src="...></img> and maybe here</p>
```

A better solution might be using JavaScript to scan all elements in the page.