### PR TITLE
Refactor the sidebar index config

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,5 +1,3 @@
-const { getSidebar } = require('../../js/utils');
-
 module.exports = {
     markdown: {
         lineNumbers: false
@@ -36,55 +34,7 @@ module.exports = {
         }],
         // 为以下路由添加侧边栏
         sidebar: {
-            '/': [
-                {
-                    title: '第零章：在开始之前',
-                    children: getSidebar('ch0'),
-                },
-                {
-                    title: '第一章上：HelloWorld',
-                    children: getSidebar('ch1p1'),
-                },
-                {
-                    title: '第一章下：深度学习基础',
-                    children: getSidebar('ch1p2'),
-                },
-                {
-                    title: '第二章上：卷积神经网络',
-                    children: getSidebar('ch2p1'),
-                },
-                {
-                    title: '第二章下：经典卷积神经网络',
-                    children: getSidebar('ch2p2'),
-                },
-                {
-                    title: '第三章上：谈一些计算机视觉方向',
-                    children: getSidebar('ch3p1'),
-                },
-                {
-                    title: '第三章下：了解更高级的技术',
-                    children: getSidebar('ch3p2'),
-                },
-                {
-                    title: '附录：永远是你的好朋友',
-                    children: getSidebar('appendix'),
-                },{
-                    title: '第五章：Playground',
-                    children: getSidebar('ch5'),
-                },
-                {
-                    title: '第-1章：TensorFlow编程策略',
-                    children: getSidebar('ch-1'),
-                },
-                {
-                    title: '第-2章：数字信号处理（DSP）',
-                    children: getSidebar('ch-2'),
-                },
-                {
-                    title: '魔法部日志（又名论文阅读日志）',
-                    children: getSidebar('unlimited-paper-works'),
-                },
-            ]
+            '/': require('./theindex').getSidebarIndex()
         }
     },
     plugins: [

--- a/docs/.vuepress/theindex.js
+++ b/docs/.vuepress/theindex.js
@@ -1,0 +1,24 @@
+const { getSidebar } = require("../../js/utils");
+
+const indexData = {
+    "ch0": "第零章：在开始之前",
+    "ch1p1": "第一章上：HelloWorld",
+    "ch1p2": "第一章下：深度学习基础",
+    "ch2p1": "第二章上：卷积神经网络",
+    "ch2p2": "第二章下：经典卷积神经网络",
+    "ch3p1": "第三章上：谈一些计算机视觉方向",
+    "ch3p2": "第三章下：了解更高级的技术",
+    "appendix": "附录：永远是你的好朋友",
+    "ch5": "第五章：Playground",
+    "ch-1": "第-1章：TensorFlow编程策略",
+    "ch-2": "第-2章：数字信号处理（DSP）",
+    "unlimited-paper-works": "魔法部日志（又名论文阅读日志）",
+};
+
+exports.getSidebarIndex = function () {
+    return Object.entries(indexData)
+        .map(([folder, title]) => ({
+            title,
+            children: getSidebar(folder)
+        }));
+};


### PR DESCRIPTION
Moved sidebar index to `docs/.vuepress/theindex.js`

```js
const indexData = {
    "ch0": "第零章：在开始之前",
    "ch1p1": "第一章上：HelloWorld",
    "ch1p2": "第一章下：深度学习基础",
    "ch2p1": "第二章上：卷积神经网络",
    "ch2p2": "第二章下：经典卷积神经网络",
    "ch3p1": "第三章上：谈一些计算机视觉方向",
    "ch3p2": "第三章下：了解更高级的技术",
    "appendix": "附录：永远是你的好朋友",
    "ch5": "第五章：Playground",
    "ch-1": "第-1章：TensorFlow编程策略",
    "ch-2": "第-2章：数字信号处理（DSP）",
    "unlimited-paper-works": "魔法部日志（又名论文阅读日志）",
};
```